### PR TITLE
Converting tags to object

### DIFF
--- a/methods/track.js
+++ b/methods/track.js
@@ -25,7 +25,7 @@ module.exports = {
 
     const validation = Joi.object().keys({
       type: Joi.string().required(),
-      tags: Joi.array(),
+      tags: Joi.object(),
       value: Joi.any().default(1),
       data: Joi.any(),
       userId: Joi.string()

--- a/methods/track.js
+++ b/methods/track.js
@@ -14,6 +14,8 @@ module.exports = {
 
     if (payload.tags && _.isString(payload.tags)) {
       const allTags = payload.tags.split(',');
+      payload.tags = {};
+
       _.each(allTags, (tag) => {
         const tagArr = tag.split('=');
         if (tagArr.length === 1) {

--- a/methods/track.js
+++ b/methods/track.js
@@ -13,7 +13,14 @@ module.exports = {
     const server = this;
 
     if (payload.tags && _.isString(payload.tags)) {
-      payload.tags = payload.tags.split(',');
+      const allTags = payload.tags.split(',');
+      _.each(allTags, (tag) => {
+        const tagArr = tag.split('=');
+        if (tagArr.length === 1) {
+          tagArr.push(1);
+        }
+        payload.tags[tagArr[0]] = tagArr[1];
+      });
     }
 
     const validation = Joi.object().keys({


### PR DESCRIPTION
Would change tags from an array of strings to an object which could use basic value assignments.

Either on the API side: 
```
{
  var: value
}
```

Or by passing in the query string: `tags=tag1=value,tag2,tag3=other-value`. (The string would need to be url-encoded in this case.) All tags that don't have assigned values get automatically assigned a `1` as a placeholder value in the created object.