### PR TITLE
Adding reporting api endpoint

### DIFF
--- a/methods/get.js
+++ b/methods/get.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const _ = require('lodash');
+
+module.exports = {
+  method(filter, done) {
+    const server = this;
+    const db = server.plugins['hapi-mongodb'].db;
+
+    const findObj = {};
+
+    if (filter.type) {
+      findObj.type = filter.type;
+    }
+
+    if (filter.tags) {
+      const allTags = filter.tags.split(',');
+      _.each(allTags, (tag) => {
+        const tagArr = tag.split('=');
+        if (tagArr.length === 1) {
+          findObj[`tags.${tag}`] = 1;
+          return;
+        }
+
+        findObj[`tags.${tagArr[0]}`] = tagArr[1];
+      });
+    }
+
+    if (filter.startDate && filter.endDate) {
+      findObj.createdOn = {
+        $gte: new Date(filter.startDate),
+        $lte: new Date(filter.endDate)
+      };
+    }
+
+    if (filter.value) {
+      findObj.value = (isNaN(filter.value / 1)) ? filter.value : filter.value / 1;
+    }
+
+    db.collection('tracks').find(findObj).toArray(done);
+  }
+};

--- a/routes/api/get.js
+++ b/routes/api/get.js
@@ -1,0 +1,14 @@
+'use strict';
+
+exports.track = {
+  method: 'GET',
+  path: '/api/get',
+  handler(request, reply) {
+    request.server.methods.get(request.query, (err, results) => {
+      reply({
+        count: results.length,
+        results
+      });
+    });
+  }
+};


### PR DESCRIPTION
Should map to all possible queries:

`type`, `tags`, `startDate` & `endDate` (both required for range based lookups), `value` (with lightweight integer conversion).

Example tags:
`tags=tag1,tag2,tag3=value` 